### PR TITLE
Add empty space at top of tubes

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
       :root {
         --tube-width: 60px;
         --tube-height: 240px;
-        --liquid-height: 60px; /* --tube-height / capacity */
+        --tube-fill-ratio: 0.9; /* Percentage of tube actually filled */
+        --liquid-height: calc(var(--tube-height) * var(--tube-fill-ratio) / 4);
         --tube-border-radius: 10px;
         --tube-bottom-radius: 30px;
         --animation-speed: 0.3s;
@@ -244,7 +245,6 @@
         :root {
           --tube-width: 50px;
           --tube-height: 200px;
-          --liquid-height: 50px;
         }
         .game-info {
           font-size: 1em;
@@ -268,7 +268,6 @@
         :root {
           --tube-width: 45px;
           --tube-height: 180px;
-          --liquid-height: 45px;
         }
         .tubes-container {
           gap: 15px;


### PR DESCRIPTION
## Summary
- add `--tube-fill-ratio` variable to define how much of a tube can be filled
- compute `--liquid-height` from `--tube-fill-ratio`
- adjust media queries to rely on this formula

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fe4912c348324a7a0e2e7e997e85c